### PR TITLE
GM-27 Explicitly set search field background color

### DIFF
--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -175,6 +175,9 @@ ul.facet-values li {
     background-color: #c1d62e;
     border-color: #000;
 	}
+  .tt-input {
+    background-color: #fff !important;
+  }
 }
 
 #main-container {


### PR DESCRIPTION
Background obscured contents of search field because search bar is black.  Explicitly set the field background to white.  Note: We are not using type ahead, so it will not affect the original intent of making the field background transparent.  reference: https://github.com/twitter/typeahead.js/issues/302