### PR TITLE
Update platforms in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
       rake
     mini_magick (4.12.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitar (0.9)
     minitest (5.16.3)
     msgpack (1.6.0)
@@ -223,6 +224,13 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.10-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -357,6 +365,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.5.4)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.5.4-aarch64-linux)
+    sqlite3 (1.5.4-arm64-darwin)
     sqlite3 (1.5.4-x86_64-darwin)
     ssrf_filter (1.1.1)
     thor (1.2.1)
@@ -401,7 +413,9 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
-  x86_64-darwin-20
+  aarch64-linux
+  arm64-darwin
+  ruby
 
 DEPENDENCIES
   blacklight (~> 7.31)


### PR DESCRIPTION
For some reason, my last commit included only the Darwin platform.  This adds platforms that we have listed in other projects.