### PR TITLE
GM-39 Make SOLR_URL for test consistent with recorded VCR_Casette

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -3,7 +3,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://localhost:8090/solr/gencon50-1.0.0" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://localhost:8090/solr/gencon50-1.0.0" %>
+  url: <%= ENV['SOLR_URL'] || "http://localhost:8090/solr/gencon50-1.0" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://localhost:8090/solr/gencon50-1.0.0" %>


### PR DESCRIPTION
Specs were failing because the SOLR_URL test environmet variable didn't match the orginally recorded solr_requests with the VCR_Cassette gem.